### PR TITLE
fix some weird breaking change related to ctx

### DIFF
--- a/pywasm/execution.py
+++ b/pywasm/execution.py
@@ -409,7 +409,8 @@ def hostfunc_call(
     valn = [stack.pop() for _ in f.functype.args][::-1]
     ctx = Ctx(store.mems)
     r = f.hostcode(ctx, *[e.n for e in valn])
-    return [Value(f.functype.rets[0], r)]
+    if r:
+        stack.add(Value(f.functype.rets[0], r))
 
 
 def wasmfunc_call(
@@ -581,8 +582,7 @@ def exec_expr(
                 stack.ext(v)
                 break
             if opcode == convention.call:
-                r = call(module, module.funcaddrs[i.immediate_arguments], store, stack)
-                stack.ext(r)
+                call(module, module.funcaddrs[i.immediate_arguments], store, stack)
                 continue
             if opcode == convention.call_indirect:
                 if i.immediate_arguments[1] != 0x00:
@@ -591,8 +591,7 @@ def exec_expr(
                 tab = store.tables[module.tableaddrs[0]]
                 if not 0 <= idx < len(tab.elem):
                     raise Exception('pywasm: undefined element index')
-                r = call(module, tab.elem[idx], store, stack)
-                stack.ext(r)
+                call(module, tab.elem[idx], store, stack)
                 continue
             continue
         if opcode == convention.drop:


### PR DESCRIPTION
ctx wasnt working with mems created in code. eg, this was compiled with wat2wasm and executed in pywasm:

```
(module
    (import "lib" "write" (func $write (param i32)))
    (memory $m 1)
    (data (i32.const 0) "Hi")
    (func $program
        i32.const 22
        call $write
    )
    (start $program)
)
```

where lib.write is a python function accepting two args (ctx,val) just to check ctx is passing properly to HostFuncs. but this was crashing due to some weird changes in hostfunc_call and exec_expr from 0.4.5. just revert these 3 lines or so to fix for our project.